### PR TITLE
fix: allow auto-detect type for source language

### DIFF
--- a/src/components/Translator.tsx
+++ b/src/components/Translator.tsx
@@ -2,10 +2,15 @@
 import React from 'react';
 import WebView from 'react-native-webview';
 import {View} from 'react-native';
-import {INJECTED_JAVASCRIPTS, LanguageCode, TranslatorType} from '..';
+import {
+  INJECTED_JAVASCRIPTS,
+  LanguageCode,
+  SourceLanguageCode,
+  TranslatorType,
+} from '..';
 
 export interface TranslatorProps<T extends TranslatorType> {
-  from: LanguageCode<T>;
+  from: SourceLanguageCode<T>;
   to: LanguageCode<T>;
   value: string;
   type?: T;

--- a/src/index.ts
+++ b/src/index.ts
@@ -193,9 +193,19 @@ export const INJECTED_JAVASCRIPTS: Record<
 };
 
 type ValueOf<T> = T[keyof T];
-export type LanguageCode<T extends TranslatorType> = ValueOf<
+
+type SpecifiedLanguageCode<T extends TranslatorType> = ValueOf<
   Pick<typeof LANGUAGE_CODES, T>
 >[number];
+
+export type LanguageCode<T extends TranslatorType> = SpecifiedLanguageCode<T>;
+
+type AutoDetectableLanguage = 'google' | 'papago';
+
+export type SourceLanguageCode<T extends TranslatorType> =
+  T extends AutoDetectableLanguage
+    ? SpecifiedLanguageCode<T> | 'auto'
+    : SpecifiedLanguageCode<T>;
 
 // Translator type
 export type TranslatorType = keyof typeof LANGUAGE_CODES;

--- a/src/providers/TranslatorProvider.tsx
+++ b/src/providers/TranslatorProvider.tsx
@@ -12,12 +12,13 @@ import {
   INJECTED_JAVASCRIPTS,
   LanguageCode,
   LOADING_MESSSAGE,
+  SourceLanguageCode,
   TranslatorType,
 } from '..';
 
 export type TranslatorContextType = {
   translate: <T extends TranslatorType = 'google'>(
-    from: LanguageCode<T>,
+    from: SourceLanguageCode<T>,
     to: LanguageCode<T>,
     value: string,
     option?: {
@@ -33,14 +34,14 @@ export const TranslatorContext = createContext<TranslatorContextType>(
 
 const TranslatorProvider: React.FC = ({children}) => {
   const [type, setType] = useState<TranslatorType>('google');
-  const [from, setFrom] = useState<LanguageCode<typeof type>>();
+  const [from, setFrom] = useState<SourceLanguageCode<typeof type>>();
   const [to, setTo] = useState<LanguageCode<typeof type>>();
   const [value, setValue] = useState('');
   const res = useRef<(result: string) => void>(null);
 
   const translate = useCallback(
     async <T extends TranslatorType = 'google'>(
-      _from: LanguageCode<T>,
+      _from: SourceLanguageCode<T>,
       _to: LanguageCode<T>,
       _value: string,
       {


### PR DESCRIPTION
Hi,
since Google Translate and Papago allow to auto-detect the source language I added a string 'auto' for prop `from` when the type is google or papago. Please review it.
Many thanks.